### PR TITLE
fix: mcim api query param `algorithm` missing

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -140,7 +140,7 @@ sites:
     checkInterval: 300
 
   - name: "MCIM-Modrinth hash"
-    url: https://mod.mcimirror.top/modrinth/v2/version_file/acac3670ee25cc10ed63136e5dd3b792acd13595
+    url: https://mod.mcimirror.top/modrinth/v2/version_file/acac3670ee25cc10ed63136e5dd3b792acd13595algorithm=sha1
     method: GET
     expectedStatusCodes: [200]
     checkInterval: 300

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -140,7 +140,7 @@ sites:
     checkInterval: 300
 
   - name: "MCIM-Modrinth hash"
-    url: https://mod.mcimirror.top/modrinth/v2/version_file/acac3670ee25cc10ed63136e5dd3b792acd13595algorithm=sha1
+    url: https://mod.mcimirror.top/modrinth/v2/version_file/acac3670ee25cc10ed63136e5dd3b792acd13595?algorithm=sha1
     method: GET
     expectedStatusCodes: [200]
     checkInterval: 300


### PR DESCRIPTION
我对齐了下 modrinth 官方，强制要求 `algorithm` 参数